### PR TITLE
DDL: add column typo example

### DIFF
--- a/db.go
+++ b/db.go
@@ -120,7 +120,7 @@ func RunMigrations() {
 		// alter table
 		ID: "202307111200",
 		Migrate: func(db *gorm.DB) error {
-			if err := db.Exec("ALTER TABLE `users` ADD `new_wrong_field` varchar(255) NOT NULL").Error; err != nil {
+			if err := db.Exec("ALTER TABLE `users` ADD `new_field` varchar(255) NOT NULL").Error; err != nil {
 				return err
 			}
 			return nil

--- a/db.go
+++ b/db.go
@@ -116,6 +116,15 @@ func RunMigrations() {
 			}
 			return nil
 		},
+	}, {
+		// alter table
+		ID: "202307111200",
+		Migrate: func(db *gorm.DB) error {
+			if err := db.Exec("ALTER TABLE `users` ADD `new_wrong_field` varchar(255) NOT NULL").Error; err != nil {
+				return err
+			}
+			return nil
+		},
 	}})
 
 	if err = m.Migrate(); err != nil {
@@ -123,5 +132,4 @@ func RunMigrations() {
 		os.Exit(1)
 	}
 	log.Println("Migration did run successfully")
-
 }

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,7 @@ import (
 // TEST_DRIVERS: sqlite, mysql, postgres, sqlserver, tidb
 
 func TestGORM(t *testing.T) {
-	user := User{Name: "jinzhu"}
+	user := User{Name: "jinzhu", NewField: "new_field"}
 
 	DB.Create(&user)
 

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type User struct {
 	Languages []Language `gorm:"many2many:UserSpeak"`
 	Friends   []*User    `gorm:"many2many:user_friends"`
 	Active    bool
+	NewField  string
 }
 
 type Account struct {

--- a/tidbcloud.yml
+++ b/tidbcloud.yml
@@ -1,4 +1,4 @@
 github:
   branch:
     allowList:
-      - "ci_example"
+      - "column_typo_example"


### PR DESCRIPTION
# How GitHub App works in this example

This example adds a new field called `new_field` in the user table. The [first commit](https://github.com/tidbcloud/branching-gorm-example/pull/1/commits/2f29d7c9ec1e83537d0d3f73ee311e6c6a7b9fe3) type the `new_field` as `wrong_new_field` and the [second commit](https://github.com/tidbcloud/branching-gorm-example/pull/1/commits/482c9dd5a0441d07f05c7918c497a51090532bfc) corrects it.

1. The test in GitHub action will fail in the first commit because of the wrong field name.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/e311949b-b06b-47f1-8280-a1c29274f78f)
![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/b702d5d7-4d8b-4f2d-af7d-b8afa385934b)

2. The test in GitHub action will succeed in the second commit which we fix the bug.

![image](https://github.com/shiyuhang0/tidbcloud-branch-gorm-example/assets/52435083/5cb0e51b-1ab0-42b8-806d-9bf67e1d7257)

# Summarize

In this example: 
1. The branch helps us find the wrong DDL in the first commit, and it will not be applied to the production database.
2. We can not execute such a test in a new database without branch. Because the `AutoMigrate` always loads the whole fields, causing an error in the new added DDL.